### PR TITLE
Better URL endpoints to register 1 bike or a batch of bikes

### DIFF
--- a/docs/tutorial/modules/ROOT/pages/implement-create-bike.adoc
+++ b/docs/tutorial/modules/ROOT/pages/implement-create-bike.adoc
@@ -194,7 +194,7 @@ We must add a method in our controller to handle the HTTP Request to register a 
 
 For this endpoint, we will consider the following request format:
 
-    POST /bike?bikeType={bikeType}&location={city}
+    POST /bikes?bikeType={bikeType}&location={city}
 
 NOTE: When designing a REST endpoint that registers a new element in our system, it is usual to model the API to use a POST request, which contains the information of the entity to create in the body. In this first example, for the sake of simplicity, we will receive the bike details as parameters on the request.
 

--- a/frontend/src/stores/bike-store.js
+++ b/frontend/src/stores/bike-store.js
@@ -19,7 +19,7 @@ export const useBikeStore = defineStore('bikes', {
     //   this.counter++;
     },
     async generateBikes(generateBikesParams){
-        let res = await fetch(URL+'/bikes?'+new URLSearchParams(generateBikesParams),{
+        let res = await fetch(URL+'/bikes/batch?'+new URLSearchParams(generateBikesParams),{
             method: "POST"
         })
     },

--- a/rental/src/main/java/io/axoniq/demo/bikerental/rental/ui/RentalController.java
+++ b/rental/src/main/java/io/axoniq/demo/bikerental/rental/ui/RentalController.java
@@ -53,7 +53,7 @@ public class RentalController {
 
     //end::ControllerInitialization[]
     //tag::registerBike[]
-    @PostMapping("/bike") // <.>
+    @PostMapping("/bikes") // <.>
     public CompletableFuture<String> registerBike(
             @RequestParam("bikeType") String bikeType,      // <.>
             @RequestParam("location") String location) {    // <.>
@@ -72,7 +72,7 @@ public class RentalController {
 
     //end::registerBike[]
     //tag::generateBikes[]
-    @PostMapping("/bikes") // <.>
+    @PostMapping("/bikes/batch") // <.>
     public CompletableFuture<Void> generateBikes(@RequestParam("count") int bikeCount,              //<.>
                                                  @RequestParam(value = "type") String bikeType) {   //<.>
         CompletableFuture<Void> all = CompletableFuture.completedFuture(null);

--- a/requests.http
+++ b/requests.http
@@ -1,12 +1,12 @@
 ### Register a new bike
 # tag::registerBike[]
-POST {{rental}}/bike?bikeType=city&location=Madrid
+POST {{rental}}/bikes?bikeType=city&location=Madrid
 
 ### end::registerBike[]
 
 ### Generate bikes
 # First, generate some bikes
-POST {{rental}}/bikes?count=60&type=city
+POST {{rental}}/bikes/batch?count=60&type=city
 Accept: application/json
 
 ### List all


### PR DESCRIPTION
For the ["Building your first Axon Framework App" tutorial ](https://library.axoniq.io/bikerental-demo/main/implement-create-bike.html) I think is better to show (as the first Endpoint) the endpoint to register a single new bike than the method that registers a batch of bikes.

I acknowledge the end point to register a batch of bikes is more convenient for the demo purposes, but I think is also a good thing to start by showing how to implement the method to register a single bike and avoid confusion in the tutorial with the ' `CompletableFuture.allOf()` when sending the command.

When I tried to merge the first draft of the tutorial I realized that the `@PostMapping` in the `generateBikes()` method changed from `@PostMapping("/")` to `@PostMapping("/bikes")`, which was the endpoint I was using for the `registerBike()` method.  I solved the collision by temporarily changing the mapping in the latter to `POST /bike` instead of `POST /bikes`.

In this PR, I'm proposing a better (more RESTful) mappings for those two endpoints :
- `POST /bikes` -> `registerBike()`
- `POST /bikes/batch` -> `generateBikes()`

 