### PR TITLE
Remove the no longer needed axon server build, and add a build of the rental monolith.

### DIFF
--- a/.github/axonserver/Dockerfile
+++ b/.github/axonserver/Dockerfile
@@ -1,5 +1,0 @@
-FROM axoniq/axonserver:latest-dev
-
-RUN curl -o /axonserver/exts/control-tower-extension-1.0-SNAPSHOT.jar https://download.axoniq.io/axonserver/control-tower-extension-1.0-SNAPSHOT.jar
-RUN curl -o /axonserver/exts/spring-retry-1.3.4.jar https://repo.maven.apache.org/maven2/org/springframework/retry/spring-retry/1.3.4/spring-retry-1.3.4.jar
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,11 +87,11 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ghcr.io/axoniq/bike-rental-ui:latest
 
-      - name: Build and push axon server
+      - name: Build and push complete Rental service
         uses: docker/build-push-action@v2
         with:
-          context: .github/axonserver
+          context: rental
           platforms: linux/amd64,linux/arm64/v8
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ghcr.io/axoniq/bike-rental-axonserver-control-tower:latest
+          tags: ghcr.io/axoniq/bike-rental:latest
 

--- a/rental/Dockerfile
+++ b/rental/Dockerfile
@@ -1,0 +1,7 @@
+FROM amazoncorretto:21
+
+WORKDIR /app
+
+ADD target/rental-0.0.1-SNAPSHOT.jar rental.jar
+
+ENTRYPOINT ["java", "-jar", "rental.jar"]


### PR DESCRIPTION
This will make it easier to run the demo, as only two applications are required instead of five. It's still possible to run all five.